### PR TITLE
DAC6-1368: Add method for generating error messages for missing tags

### DIFF
--- a/app/helpers/XmlErrorMessageHelper.scala
+++ b/app/helpers/XmlErrorMessageHelper.scala
@@ -257,7 +257,8 @@ class XmlErrorMessageHelper {
 
   private def getErrorMessageForMissingTags(element: String): Option[Message] =
     element match {
-      case "ID" | "DocSpec" | "ReportableTaxPayer" | "Structure" | "Address" | "MessageSpec" | "MdrBody" | "Name" => Some(missingInfoMessage(element))
+      case "ID" | "DocSpec" | "ReportableTaxPayer" | "Structure" | "Address" | "MessageSpec" | "MdrBody" =>
+        Some(missingInfoMessage(element))
       case "Disclosing" => Some(Message("xml.add.element", Seq(element)))
       case _            => Some(Message("xml.add.line", Seq(element)))
 

--- a/app/helpers/XmlErrorMessageHelper.scala
+++ b/app/helpers/XmlErrorMessageHelper.scala
@@ -26,7 +26,11 @@ class XmlErrorMessageHelper {
 
   def generateErrorMessages(errors: ListBuffer[SaxParseError]): List[GenericError] = {
     val errorsGroupedByLineNumber = errors.groupBy(saxParseError => saxParseError.lineNumber)
-
+    println("****************************************")
+    println("****************************************")
+    println(errorsGroupedByLineNumber)
+    println("****************************************")
+    println("****************************************")
     errorsGroupedByLineNumber.map { groupedErrors =>
       if (groupedErrors._2.length <= 2) {
         val error1 = groupedErrors._2.head.errorMessage
@@ -254,8 +258,11 @@ class XmlErrorMessageHelper {
     val vowels = "aeiouAEIOU"
     if (vowels.contains(elementName.head) || elementName.toLowerCase.startsWith("mdr")) {
       Message("xml.add.an.element", Seq(elementName))
-    } else Message("xml.add.a.element", Seq(elementName))
-
+    } else if (elementName.contains("Jurisdictions")) {
+      Message("xml.add.one.or.more.elements", Seq(elementName))
+    } else {
+      Message("xml.add.a.element", Seq(elementName))
+    }
   }
 
   def invalidCodeMessage(elementName: String, allowedValues: Option[String] = None): Option[Message] =

--- a/app/helpers/XmlErrorMessageHelper.scala
+++ b/app/helpers/XmlErrorMessageHelper.scala
@@ -146,6 +146,11 @@ class XmlErrorMessageHelper {
     val formatOfSecondError = """cvc-type.3.1.3: The value '(.*?)' of element '(.*?)' is not valid.""".stripMargin.r
 
     formattedError match {
+      case formatOfFirstError("", "(MDR)") =>
+        errorMessage2 match {
+          case formatOfSecondError(_, element) =>
+            Some(Message("xml.add.line.messageType", Seq(element)))
+        }
       case formatOfFirstError(suppliedValue, allowedValues) =>
         errorMessage2 match {
           case formatOfSecondError(_, element) =>
@@ -232,8 +237,15 @@ class XmlErrorMessageHelper {
       """cvc-complex-type.2.4.b: The content of element '(.*?)' is not complete. One of '"urn:oecd:ties:mdr:v1":(.*?)' is expected.""".stripMargin.r
 
     formattedError match {
+      case format("Arrangement", element) =>
+        val formattedElement = element.replaceAll(", \"urn:oecd:ties:mdr:v1\":", " or ")
+        Some(Message("xml.empty.tag", Seq("Arrangement", formattedElement)))
+      case format("ID", element) =>
+        val formattedElement = element.replaceAll(", \"urn:oecd:ties:mdr:v1\":", " or ")
+        Some(Message("xml.empty.tag", Seq("ID", formattedElement)))
       case format(parent, element) =>
-        Some(Message("xml.empty.tag", Seq(parent, element)))
+        val formattedElement = element.replaceAll("(.*?):", "")
+        Some(Message("xml.empty.tag", Seq(parent, formattedElement)))
       case _ => None
     }
   }

--- a/app/helpers/XmlErrorMessageHelper.scala
+++ b/app/helpers/XmlErrorMessageHelper.scala
@@ -229,11 +229,11 @@ class XmlErrorMessageHelper {
 
     val formattedError = errorMessage.replaceAll("[{}]", "")
     val format =
-      """cvc-complex-type.2.4.b: The content of element '(.*?)' is not complete. One of '"urn:oecd:ties:mdr:v1":(?:.*)' is expected.""".stripMargin.r
+      """cvc-complex-type.2.4.b: The content of element '(.*?)' is not complete. One of '"urn:oecd:ties:mdr:v1":(.*?)' is expected.""".stripMargin.r
 
     formattedError match {
-      case format(element) =>
-        getErrorMessageForEmptyTags(element)
+      case format(parent, element) =>
+        Some(Message("xml.empty.tag", Seq(parent, element)))
       case _ => None
     }
   }
@@ -255,19 +255,11 @@ class XmlErrorMessageHelper {
       case _ => None
     }
 
-  private def getErrorMessageForEmptyTags(element: String) =
+  private def getErrorMessageForMissingTags(element: String): Option[Message] =
     element match {
-      case "MessageSpec" | "MdrBody" | "ReportableTaxPayer" | "Structure" => Some(Message("xml.empty.tag", Seq(element)))
-//      case "Name"                                                         => Some(Message("xml.add.a.element", Seq(element)))
-      case _ => Some(Message("xml.add.a.element", Seq(element)))
-
-    }
-
-  private def getErrorMessageForMissingTags(element: String) =
-    element match {
-      case "ID" | "DocSpec" | "ReportableTaxPayer" | "Structure" | "Address" | "MessageSpec" | "MdrBody" => Some(missingInfoMessage(element))
-      case "Disclosing"                                                                                  => Some(Message("xml.add.element", Seq(element)))
-      case _                                                                                             => Some(Message("xml.add.line", Seq(element)))
+      case "ID" | "DocSpec" | "ReportableTaxPayer" | "Structure" | "Address" | "MessageSpec" | "MdrBody" | "Name" => Some(missingInfoMessage(element))
+      case "Disclosing" => Some(Message("xml.add.element", Seq(element)))
+      case _            => Some(Message("xml.add.line", Seq(element)))
 
     }
 }

--- a/test/helpers/XmlErrorMessageHelperSpec.scala
+++ b/test/helpers/XmlErrorMessageHelperSpec.scala
@@ -266,7 +266,6 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           "Summary",
           "ResCountryCode",
           "TIN",
-          "Name",
           "FirstName",
           "LastName",
           "CountryCode",
@@ -288,7 +287,8 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           "DocSpec",
           "ReportableTaxPayer",
           "Structure",
-          "MessageSpec"
+          "MessageSpec",
+          "Name"
         )
 
         elements.map { element =>
@@ -326,6 +326,16 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         )
         val result = helper.generateErrorMessages(ListBuffer(error1))
         result mustBe List(GenericError(lineNumber, Message("xml.add.element", Seq("Disclosing"))))
+      }
+
+      "must return 'X is missing one or more fields, including Y' message for relevant missing tag values" in {
+
+        val error1 = SaxParseError(
+          lineNumber,
+          s"""cvc-complex-type.2.4.b: The content of element 'ParentElement' is not complete. One of '{\"urn:oecd:ties:mdr:v1\":ChildElement}' is expected."""
+        )
+        val result = helper.generateErrorMessages(ListBuffer(error1))
+        result mustBe List(GenericError(lineNumber, Message("xml.empty.tag", Seq("ParentElement", "ChildElement"))))
       }
     }
 

--- a/test/helpers/XmlErrorMessageHelperSpec.scala
+++ b/test/helpers/XmlErrorMessageHelperSpec.scala
@@ -17,8 +17,7 @@
 package helpers
 
 import base.SpecBase
-import models.validation.{GenericError, SaxParseError}
-import models.validation.Message
+import models.validation.{GenericError, Message, SaxParseError}
 
 import scala.collection.mutable.ListBuffer
 
@@ -36,7 +35,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
       "must return correct error for missing attribute error'" in {
         val missingAttributeError = SaxParseError(lineNumber, "cvc-complex-type.4: Attribute 'currCode' must appear on element 'Amount'.")
         val result                = helper.generateErrorMessages(ListBuffer(missingAttributeError))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("Amount currCode"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.an.element", List("Amount currCode"))))
       }
 
       "must return correct error for unexpected error message'" in {
@@ -68,7 +67,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         val missingElementError2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'Street' is not valid.")
 
         val result = helper.generateErrorMessages(ListBuffer(missingElementError1, missingElementError2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("Street"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.a.element", List("Street"))))
       }
 
       "must return correct error for missing ConcernedMS'" in {
@@ -80,7 +79,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'ConcernedMS' is not valid.")
 
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("ConcernedMS"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.a.element", List("ConcernedMS"))))
       }
 
       "must return correct error for missing birthplace'" in {
@@ -91,7 +90,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           )
         val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'BirthPlace' is not valid.")
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("BirthPlace"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.a.element", List("BirthPlace"))))
       }
 
       "must return correct error when length exceed for TIN'" in {
@@ -114,7 +113,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           )
         val error2 = SaxParseError(lineNumber, "cvc-complex-type.2.2: Element 'OrganisationName' must have no element [children], and the value must be valid.")
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("OrganisationName"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.an.element", List("OrganisationName"))))
       }
 
       "must return correct error when allowed length exceeded" in {
@@ -165,27 +164,6 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         result mustBe List(GenericError(lineNumber, Message("xml.date.format", List("ImplementingDate"))))
       }
 
-      "must return correct error for invalid Intermediary Capacity" in {
-        val error1 = SaxParseError(
-          lineNumber,
-          "cvc-enumeration-valid: Value 'DAC61102fggg' is not facet-valid with respect to enumeration '[DAC61101, DAC61102]'. It must be a value from the enumeration."
-        )
-        val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value 'DAC61102fggg' of element 'Capacity' is not valid.")
-
-        val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.defaultMessage")))
-      }
-
-      "must return correct error for invalid TaxPayer Capacity" in {
-        val error1 = SaxParseError(
-          lineNumber,
-          "cvc-enumeration-valid: Value 'DAC61105hjkjk' is not facet-valid with respect to enumeration '[DAC61104, DAC61105, DAC61106]'. It must be a value from the enumeration."
-        )
-        val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value 'DAC61105hjkjk' of element 'Capacity' is not valid.")
-        val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.defaultMessage")))
-      }
-
       "must return correct error for line (value and tags)" in {
 
         val error1 = SaxParseError(
@@ -212,7 +190,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'AffectedPerson' is not valid.")
 
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("AssociatedEnterprise/AffectedPerson"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.an.element", List("AssociatedEnterprise/AffectedPerson"))))
       }
 
       "must return correct error for missing other boolean value" in {
@@ -221,7 +199,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'InitialDisclosureMA' is not valid.")
 
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("InitialDisclosureMA"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.an.element", List("InitialDisclosureMA"))))
       }
 
       "must return correct error for invalid boolean value" in {
@@ -264,9 +242,91 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           )
         val error2 = SaxParseError(lineNumber, "cvc-type.3.1.3: The value '' of element 'MessageRefId' is not valid.")
         val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-        result mustBe List(GenericError(lineNumber, Message("xml.enter.an.element", List("MessageRefId"))))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.a.element", List("MessageRefId"))))
       }
 
+      "must return 'Add a line for' message for relevant missing tag values" in {
+        val elements = List(
+          "Jurisdictions",
+          "TransmittingCountry",
+          "ReceivingCountry",
+          "MessageType",
+          "MessageRefId",
+          "MessageTypeIndic",
+          "Timestamp",
+          "Capacity",
+          "Nexus",
+          "DocTypeIndic",
+          "DocRefId",
+          "Role",
+          "Arrangement",
+          "DisclosureDate",
+          "Type",
+          "Narrative",
+          "Summary",
+          "ResCountryCode",
+          "TIN",
+          "Name",
+          "FirstName",
+          "LastName",
+          "CountryCode",
+          "City"
+        )
+
+        elements.map { element =>
+          val error1 = SaxParseError(
+            lineNumber,
+            s"""cvc-complex-type.2.4.a: Invalid content was found starting with element 'ABC'. One of '{\"urn:oecd:ties:mdr:v1\":$element}' is expected."""
+          )
+          val result = helper.generateErrorMessages(ListBuffer(error1))
+          result mustBe List(GenericError(lineNumber, Message("xml.add.line", Seq(element))))
+        }
+      }
+
+      "must return 'Add a' message for relevant missing tag values" in {
+        val elements = List(
+          "DocSpec",
+          "ReportableTaxPayer",
+          "Structure",
+          "MessageSpec"
+        )
+
+        elements.map { element =>
+          val error1 = SaxParseError(
+            lineNumber,
+            s"""cvc-complex-type.2.4.a: Invalid content was found starting with element 'ABC'. One of '{\"urn:oecd:ties:mdr:v1\":$element}' is expected."""
+          )
+          val result = helper.generateErrorMessages(ListBuffer(error1))
+          result mustBe List(GenericError(lineNumber, Message("xml.add.a.element", Seq(element))))
+        }
+      }
+
+      "must return 'Add an' message for relevant missing tag values" in {
+        val elements = List(
+          "ID",
+          "Address",
+          "MdrBody"
+        )
+
+        elements.map { element =>
+          val error1 = SaxParseError(
+            lineNumber,
+            s"""cvc-complex-type.2.4.a: Invalid content was found starting with element 'ABC'. One of '{\"urn:oecd:ties:mdr:v1\":$element}' is expected."""
+          )
+          val result = helper.generateErrorMessages(ListBuffer(error1))
+          result mustBe List(GenericError(lineNumber, Message("xml.add.an.element", Seq(element))))
+        }
+      }
+
+      "must return 'Add' message for relevant missing tag values" in {
+
+        val error1 = SaxParseError(
+          lineNumber,
+          s"""cvc-complex-type.2.4.a: Invalid content was found starting with element 'ABC'. One of '{\"urn:oecd:ties:mdr:v1\":Disclosing}' is expected."""
+        )
+        val result = helper.generateErrorMessages(ListBuffer(error1))
+        result mustBe List(GenericError(lineNumber, Message("xml.add.element", Seq("Disclosing"))))
+      }
     }
 
     "invalidCodeMessage" - {
@@ -291,9 +351,9 @@ class XmlErrorMessageHelperSpec extends SpecBase {
         result mustBe Some(Message("xml.not.allowed.value", List("Reason")))
       }
 
-      "must return correct message for 'IntermediaryNexus'" in {
-        val result = helper.invalidCodeMessage("IntermediaryNexus")
-        result mustBe Some(Message("xml.not.allowed.value", List("IntermediaryNexus")))
+      "must return correct message for 'Nexus'" in {
+        val result = helper.invalidCodeMessage("Nexus")
+        result mustBe Some(Message("xml.not.allowed.value", List("Nexus")))
       }
 
       "must return correct message for 'RelevantTaxpayerNexus'" in {

--- a/test/helpers/XmlErrorMessageHelperSpec.scala
+++ b/test/helpers/XmlErrorMessageHelperSpec.scala
@@ -266,6 +266,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           "Summary",
           "ResCountryCode",
           "TIN",
+          "Name",
           "FirstName",
           "LastName",
           "CountryCode",
@@ -287,8 +288,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           "DocSpec",
           "ReportableTaxPayer",
           "Structure",
-          "MessageSpec",
-          "Name"
+          "MessageSpec"
         )
 
         elements.map { element =>

--- a/test/resources/mdr/invalid.xml
+++ b/test/resources/mdr/invalid.xml
@@ -204,7 +204,6 @@
                     <CrsAvoidance>
                         <DisclosureDate>12-04-2021</DisclosureDate>
                         <Reason>MDR701</Reason>
-                        <Type>MDR801</Type>
                         <OtherInfo>Other inforamtion</OtherInfo>
                         <StructureChart>
                             <ID>

--- a/test/services/validation/SubmissionValidationEngineSpec.scala
+++ b/test/services/validation/SubmissionValidationEngineSpec.scala
@@ -137,7 +137,7 @@ class SubmissionValidationEngineSpec extends SpecBase {
         .thenReturn(Left(ListBuffer(addressError1, addressError2, cityError1, cityError2)))
 
       val expectedErrors =
-        Seq(GenericError(20, Message("xml.enter.an.element", List("Street"))), GenericError(27, Message("xml.enter.an.element", List("City"))))
+        Seq(GenericError(20, Message("xml.add.a.element", List("Street"))), GenericError(27, Message("xml.add.a.element", List("City"))))
 
       Await.result(validationEngine.validateUploadSubmission(Some(source)), 10.seconds) mustBe SubmissionValidationFailure(ValidationErrors(expectedErrors))
     }
@@ -148,7 +148,7 @@ class SubmissionValidationEngineSpec extends SpecBase {
 
       when(mockXmlValidationService.validateXML(any[Option[String]](), any[Option[NodeSeq]]())).thenReturn(Left(ListBuffer(missingAttributeError)))
 
-      val expectedErrors = Seq(GenericError(175, Message("xml.enter.an.element", List("Amount currCode"))))
+      val expectedErrors = Seq(GenericError(175, Message("xml.add.an.element", List("Amount currCode"))))
 
       Await.result(validationEngine.validateUploadSubmission(Some(source)), 10.seconds) mustBe SubmissionValidationFailure(ValidationErrors(expectedErrors))
     }


### PR DESCRIPTION
- Covers all fields highlighted in yellow on the XML error spreadsheet