### PR TITLE
DAC6-2757: Return 422 for invalid xml

### DIFF
--- a/app/controllers/validation/SubmissionValidationController.scala
+++ b/app/controllers/validation/SubmissionValidationController.scala
@@ -48,7 +48,7 @@ class SubmissionValidationController @Inject() (
 
           case InvalidXmlError(saxException) =>
             logger.warn("InvalidXmlError: Failed to validate xml submission")
-            BadRequest(InvalidXmlError(saxException).toString)
+            UnprocessableEntity(InvalidXmlError(saxException).toString)
 
           case _ =>
             logger.warn("Failed to validate xml submission")

--- a/test/controllers/validation/SubmissionValidationControllerSpec.scala
+++ b/test/controllers/validation/SubmissionValidationControllerSpec.scala
@@ -69,14 +69,14 @@ class SubmissionValidationControllerSpec extends SpecBase with BeforeAndAfterEac
       status(result) mustBe OK
     }
 
-    "must return 400 and a bad request when validation fails" in {
+    "must return unprocessable entity (422) when xml file validation fails" in {
       when(mockUploadSubmissionValidationEngine.validateUploadSubmission(any[String]()))
         .thenReturn(Future.successful(InvalidXmlError("")))
 
       val request = FakeRequest(POST, routes.SubmissionValidationController.validateSubmission.url).withJsonBody(Json.toJson(UpscanURL("someUrl")))
       val result  = route(application, request).value
 
-      status(result) mustBe BAD_REQUEST
+      status(result) mustBe UNPROCESSABLE_ENTITY
     }
 
     "return 500 and an internal server error when upscan URL is missing" in {


### PR DESCRIPTION
In order to avoid alerting for cases when an invalid XML file is submitted, this PR returns an error 422 (Unprocessable entity) instead of a 400 (Bad request) when the submitted XML file fails validation.