### PR TITLE
DAC6-2777: Updated SDES checksum algorithm

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,7 +171,7 @@ sdes {
    client-id = "client-id"
    information-type = "mdr-report"
    recipient-or-sender = "mdr-reporting"
-   checksum-algorithm = "SHA2"
+   checksum-algorithm = "SHA-256"
 }
 
 features {


### PR DESCRIPTION
Integration testing has shown we needed to use SHA-256 not SHA2.

This was verified via QA app config. Makes sense to merge it down into the base config.