### PR TITLE
Revert "DAC6-2777: Updated SDES checksum algorithm"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,7 +171,7 @@ sdes {
    client-id = "client-id"
    information-type = "mdr-report"
    recipient-or-sender = "mdr-reporting"
-   checksum-algorithm = "SHA-256"
+   checksum-algorithm = "SHA2"
 }
 
 features {


### PR DESCRIPTION
Reverts hmrc/mandatory-disclosure-rules#140

Stubbed services do not yet support SHA-256 which is causing problems running the service locally.