### PR TITLE
Tidied up the SDES callback controller

### DIFF
--- a/it/base/SpecBase.scala
+++ b/it/base/SpecBase.scala
@@ -38,12 +38,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{OptionValues, TryValues}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Configuration
-import play.api.inject.Injector
-import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
-import uk.gov.hmrc.http.HeaderCarrier
 
 trait SpecBase
   extends AnyFreeSpec


### PR DESCRIPTION
* Add a log if we get an invalid JSON payload from SDES
* Merged the FileReady, FileReceived, and FileProcessed callbacks into one
* Reformatted the FileProcessingFailure callback
* Added several code comments to explain what's going on

Plus: removed some unused imports from the SpecBase