### PR TITLE
DAC6-3121: Amended StaleFileTask syntax

### DIFF
--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -59,11 +59,10 @@ class StaleFileTask @Inject() (actorSystem: ActorSystem,
 
           repository
             .findStaleSubmissions()
-            .map(files => files.map(file => logger.warn(s"StaleFileTask: Stale file found - conversationId: ${file._id.value}, filename: ${file.name}")))
-
-          logger.info("StaleFileTask: Complete")
-
-          Future.unit
+            .map { files =>
+              files.foreach(file => logger.warn(s"StaleFileTask: Stale file found - conversationId: ${file._id.value}, filename: ${file.name}"))
+              logger.info("StaleFileTask: Complete")
+            }
         }
         .onComplete {
           case Success(_) => ()

--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -61,7 +61,9 @@ class StaleFileTask @Inject() (actorSystem: ActorSystem,
             .findStaleSubmissions()
             .map(files => files.map(file => logger.warn(s"StaleFileTask: Stale file found - conversationId: ${file._id.value}, filename: ${file.name}")))
 
-          Future.successful(logger.info("StaleFileTask: Complete"))
+          logger.info("StaleFileTask: Complete")
+
+          Future.unit
         }
         .onComplete {
           case Success(_) => ()

--- a/it/base/SpecBase.scala
+++ b/it/base/SpecBase.scala
@@ -38,12 +38,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{OptionValues, TryValues}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Configuration
-import play.api.inject.Injector
-import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
-import uk.gov.hmrc.http.HeaderCarrier
 
 trait SpecBase
   extends AnyFreeSpec

--- a/it/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/repositories/submission/FileDetailsRepositorySpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepositorySupport[FileDetails] {
 
@@ -35,6 +36,7 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
 
   private val mockAppConfig = mock[AppConfig]
   when(mockAppConfig.cacheTtl) thenReturn 1
+  when(mockAppConfig.staleTaskAlertAfter) thenReturn 2.hours
 
   override lazy val repository = new FileDetailsRepository(mongoComponent, mockAppConfig, metricsService)
 


### PR DESCRIPTION
Simplified the stale file task syntax (added bonus: fixes the compiler warning for "discarding a non unit value")

Removed unused imports from SpecBase and fixed an issue with the file details repository integration tests