### PR TITLE
DAC6-3121: Updated how stale file logs are done

### DIFF
--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -67,8 +67,8 @@ class StaleFileTask @Inject() (actorSystem: ActorSystem,
         .onComplete {
           case Success(result) =>
             result match {
-              case Some(staleRecordCount) => logger.info(s"StaleFileTask: Complete. ${staleRecordCount} stale files found.")
-              case None => ()
+              case Some(staleRecordCount) => logger.info(s"StaleFileTask: Complete. $staleRecordCount stale files found.")
+              case None                   => ()
             }
           case Failure(e) => logger.warn(s"StaleFileTask: An error occurred: ${e.getMessage}", e)
         }

--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -60,12 +60,16 @@ class StaleFileTask @Inject() (actorSystem: ActorSystem,
           repository
             .findStaleSubmissions()
             .map { files =>
-              files.foreach(file => logger.warn(s"StaleFileTask: Stale file found - conversationId: ${file._id.value}, filename: ${file.name}"))
-              logger.info("StaleFileTask: Complete")
+              files.foreach(file => logger.warn(s"StaleFileTask: Stale file found. ConversationId: ${file._id.value}, Filename: ${file.name}"))
+              files.length
             }
         }
         .onComplete {
-          case Success(_) => ()
+          case Success(result) =>
+            result match {
+              case Some(staleRecordCount) => logger.info(s"StaleFileTask: Complete. ${staleRecordCount} stale files found.")
+              case None => ()
+            }
           case Failure(e) => logger.warn(s"StaleFileTask: An error occurred: ${e.getMessage}", e)
         }
     }


### PR DESCRIPTION
Moved the "complete" log out into the `.onComplete` method in an attempt to fix some log ordering issues.

Important to note that the `.onComplete` function is hit whether a lock is acquired or not:
* If a lock is not acquired, the `.withLock` function is not called and you will get a `Success(None)` in the `.onComplete` (we do not care about logging this).
* If a lock is acquired, the `.withLock` function will be called and you will get a `Success(Some)` containing whatever it returned (we do care about logging this).