### PR TITLE
DAC6-3121: Update stale file task config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -175,8 +175,8 @@ sdes {
 
 tasks {
   staleFiles {
-    enabled = false
-    interval = 10 seconds
+    enabled = true
+    interval = 10 minutes
     alertAfter = 2 hours
   }
 }


### PR DESCRIPTION
Now this has been tested we can enable it by default and reduce the frequency of the checks - thereby reducing server load and the amount of logs we are creating.