### PR TITLE
Updated SDES checksum algorithm

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -170,7 +170,7 @@ sdes {
    client-id = "client-id"
    information-type = "mdr-report"
    recipient-or-sender = "mdr-reporting"
-   checksum-algorithm = "SHA2"
+   checksum-algorithm = "SHA-256"
 }
 
 tasks {


### PR DESCRIPTION
The SDES stub has recently been updated by the PlatOps team:
https://github.com/hmrc/sdes-stub/pull/22

It now supports MD5, SHA-256, and SHA-512 checksum algorithms.

SHA2 is no longer supported.

We already use SHA-256 on environments which are connected to the real SDES (QA & Production) but this was not supported by sdes-stub until now so we had to use SHA2 on stubbed environments.

We can now make SHA-256 the default across all environments and no longer need specific overrides for QA and Production.